### PR TITLE
Typescript: make textInputProps optional

### DIFF
--- a/GooglePlacesAutocomplete.d.ts
+++ b/GooglePlacesAutocomplete.d.ts
@@ -374,7 +374,7 @@ interface GooglePlacesAutocompleteProps extends TextInputProps {
   requestUrl?: RequestUrl;
 
   // text input props & ref
-  textInputProps: TextInputProps & {
+  textInputProps?: TextInputProps & {
     ref?: React.MutableRefObject<TextInput | null> | undefined;
   };
 


### PR DESCRIPTION
As far as I can see in examples, `textInputProps` is not a required prop. This PR fixes typescript definitions to make it optional